### PR TITLE
Prepare publish-ready package metadata, docs, and production Android package IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
 ## 0.0.1
 
-* TODO: Describe initial release.
+Initial production release of the `urovo_rfid` Flutter plugin.
+
+### Added
+- Android plugin implementation backed by Urovo USDK / RFID native libraries.
+- Public Dart API (`UrovoRfid`) for reader lifecycle and RFID operations:
+  - `init`, `startInventory`, `stopInventory`
+  - `readTag`, `writeTag`, `writeTagEpc`
+  - `getOutputPower`, `setOutputPower`
+  - `setInventoryParameter`, `enableScanHead`
+- Inventory event stream (`inventoryStream`) bridged from native callback events.
+
+### Platform scope
+- **Android only** (Urovo handheld devices with supported RFID hardware/firmware).
+- No iOS, web, macOS, Windows, or Linux implementation in this release.
+
+### Known limitations
+- Native event payloads include raw event keys (for example `event_inventory_tag`), so consumers must parse the envelope to extract EPC/TID/RSSI data.
+- `setInventoryParameter` currently expects a native JSON string format; Dart callers should validate integration behavior against target firmware.
+- `readTag` and `writeTag` return values map directly to native SDK behavior/codes, which may vary by Urovo SDK version and reader model.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,190 @@
 # urovo_rfid
 
-A Flutter plugin for RFID device integration.
+`urovo_rfid` is a Flutter plugin for integrating **Urovo Android RFID handheld devices** through the Urovo USDK and RFID native libraries.
 
-## Documentation
+## Platform support
 
-Detailed SDK usage and API references are available in the [RFID Development Documentation](docs/rfid_development_documentation.md).
+- ✅ **Android**: supported
+- ❌ iOS / Web / macOS / Windows / Linux: not implemented
 
-## Getting Started
+This package is intended for Urovo enterprise handhelds that include an RFID module and compatible firmware/SDK stack.
 
-This project is a starting point for a Flutter [plug-in package](https://flutter.dev/to/develop-plugins),
-a specialized package that includes platform-specific implementation code for Android and/or iOS.
+## Device and SDK prerequisites
 
-For help getting started with Flutter development, view the [online documentation](https://docs.flutter.dev),
-which offers tutorials, samples, guidance on mobile development, and a full API reference.
+Before using this plugin, ensure all of the following are true:
 
+1. Your target device is a Urovo Android handheld with built-in or attached RFID hardware.
+2. The app includes Urovo native dependencies expected by this plugin (`platform_sdk_v3.1.221124.jar`, `URFIDLibrary-v2.4.0125.aar`).
+3. Your Flutter/Android project is configured for:
+   - Flutter plugin support
+   - Android `minSdkVersion` 21 or higher
+   - Runtime permissions required by your target Urovo model and Android version
+4. You test on real hardware (the RFID APIs are not usable on generic emulators).
+
+## Installation
+
+Add the package to `pubspec.yaml`:
+
+```yaml
+dependencies:
+  urovo_rfid: ^0.0.1
+```
+
+Then install dependencies:
+
+```bash
+flutter pub get
+```
+
+## API quick reference
+
+The main entry point is `UrovoRfid`:
+
+- `Future<bool?> init()`
+- `Future<void> startInventory(int session)`
+- `Future<void> stopInventory()`
+- `Stream<Map<String, dynamic>> get inventoryStream`
+- `Future<Map<String, dynamic>?> readTag(...)`
+- `Future<int?> writeTag(...)`
+- `Future<int?> writeTagEpc(...)`
+- `Future<int?> getOutputPower()`
+- `Future<int?> setOutputPower(int power)`
+- `Future<void> setInventoryParameter(Map<String, dynamic> params)`
+- `Future<void> enableScanHead(bool enable)`
+
+## Full usage examples
+
+### 1) Initialize and subscribe to inventory events
+
+```dart
+import 'dart:async';
+import 'package:urovo_rfid/urovo_rfid.dart';
+
+final rfid = UrovoRfid();
+StreamSubscription<Map<String, dynamic>>? _sub;
+
+Future<void> setupRfid() async {
+  final initialized = await rfid.init();
+  if (initialized != true) {
+    throw Exception('RFID init failed');
+  }
+
+  _sub = rfid.inventoryStream.listen((event) {
+    // Native events are delivered as envelopes; inspect keys carefully.
+    if (event.containsKey('event_inventory_tag')) {
+      final payload = event['event_inventory_tag'];
+      // payload may be a JSON string from native side (EPC/TID/RSSI).
+      print('Tag event: $payload');
+    } else if (event.containsKey('event_inventory_tag_end')) {
+      print('Inventory cycle ended');
+    } else if (event.containsKey('event_init')) {
+      print('Native init event: ${event['event_init']}');
+    }
+  }, onError: (error, stackTrace) {
+    print('Inventory stream error: $error');
+  });
+}
+
+Future<void> disposeRfid() async {
+  await _sub?.cancel();
+}
+```
+
+### 2) Start/stop inventory scanning
+
+```dart
+Future<void> runInventorySession(UrovoRfid rfid) async {
+  // Session is forwarded to the native Urovo RFID manager.
+  await rfid.startInventory(0);
+
+  // ... collect inventory events through inventoryStream ...
+
+  await rfid.stopInventory();
+}
+```
+
+### 3) Read tag memory
+
+```dart
+Future<void> readExample(UrovoRfid rfid, String epc) async {
+  // 4-byte access password (example only).
+  const password = <int>[0x00, 0x00, 0x00, 0x00];
+
+  final result = await rfid.readTag(
+    epc,
+    1, // memory bank
+    2, // word start
+    6, // word count
+    password,
+  );
+
+  print('readTag result: $result');
+}
+```
+
+### 4) Write tag memory / EPC
+
+```dart
+Future<void> writeExample(UrovoRfid rfid, String epc) async {
+  const password = <int>[0x00, 0x00, 0x00, 0x00];
+
+  final writeCode = await rfid.writeTag(
+    epc,
+    password,
+    3, // memory bank
+    2, // word start
+    <int>[0x11, 0x22, 0x33, 0x44],
+  );
+
+  if (writeCode == 0) {
+    print('writeTag succeeded');
+  } else {
+    print('writeTag failed with code: $writeCode');
+  }
+
+  final epcCode = await rfid.writeTagEpc(epc, '00000000', '300833B2DDD9014000000001');
+  print('writeTagEpc code: $epcCode');
+}
+```
+
+## Error handling semantics
+
+This plugin exposes two error surfaces:
+
+1. **MethodChannel invocation failures**
+   - Native side can return a Flutter `PlatformException` (for example, if RFID manager is not initialized).
+   - Handle with `try/catch` around async API calls.
+
+2. **Native return codes and event payloads**
+   - Many calls return integer result codes from Urovo SDK APIs (`0` is commonly success).
+   - Some failure cases return a unified plugin code (`-19`) when arguments are missing/invalid on native side.
+   - Inventory and init status are emitted as event stream entries (`event_inventory_tag`, `event_inventory_tag_end`, `event_init`).
+
+Recommended pattern:
+
+```dart
+try {
+  final code = await rfid.setOutputPower(26);
+  if (code != 0) {
+    // Map SDK-specific code to app-level error UI/logging.
+  }
+} on PlatformException catch (e) {
+  // Transport/initialization/channel error
+  print('PlatformException: ${e.code} ${e.message}');
+}
+```
+
+## Permission and hardware requirements
+
+Because this plugin delegates to vendor SDK behavior, required permissions can vary by device model and Android release. In production deployments, verify all of the following in your app:
+
+- Device has operational Urovo RFID hardware.
+- Vendor services/firmware required by Urovo USDK are present.
+- Android runtime permissions required for scanning workflows are granted (for example, permissions tied to hardware scan features and device management on your target model).
+- Any enterprise policy (MDM/EMM) restrictions allow RFID service access.
+
+> Tip: validate the full read/write/inventory lifecycle on each hardware SKU you support; Urovo SDK behavior can differ by firmware and reader module revision.
+
+## Additional documentation
+
+Detailed background notes are available in [`docs/rfid_development_documentation.md`](docs/rfid_development_documentation.md).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-group = "com.example.urovo_rfid"
+group = "com.urovo.plugins.rfid"
 version = "1.0-SNAPSHOT"
 
 buildscript {
@@ -28,7 +28,7 @@ apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
 android {
-    namespace = "com.example.urovo_rfid"
+    namespace = "com.urovo.plugins.rfid"
 
     compileSdk = 35
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.example.urovo_rfid">
+  package="com.urovo.plugins.rfid">
 </manifest>

--- a/android/src/main/java/com/urovo/plugins/rfid/UrovoRfidPlugin.java
+++ b/android/src/main/java/com/urovo/plugins/rfid/UrovoRfidPlugin.java
@@ -1,4 +1,4 @@
-package com.example.urovo_rfid;
+package com.urovo.plugins.rfid;
 
 import android.app.Activity;
 import android.os.Handler;

--- a/android/src/test/kotlin/com/urovo/plugins/rfid/UrovoRfidPluginTest.kt
+++ b/android/src/test/kotlin/com/urovo/plugins/rfid/UrovoRfidPluginTest.kt
@@ -1,4 +1,4 @@
-package com.example.urovo_rfid
+package com.urovo.plugins.rfid
 
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.urovo_rfid_example"
+    namespace = "com.urovo.urovo_rfid_example"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = "27.0.12077973"
 
@@ -20,8 +20,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.urovo_rfid_example"
+        applicationId = "com.urovo.urovo_rfid_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/example/android/app/src/main/kotlin/com/urovo/urovo_rfid_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/urovo/urovo_rfid_example/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.urovo_rfid_example
+package com.urovo.urovo_rfid_example
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,15 @@
 name: urovo_rfid
-description: "A new Flutter plugin project."
+description: "Flutter plugin for integrating Urovo Android RFID handheld readers via the Urovo USDK."
 version: 0.0.1
-homepage:
+homepage: https://github.com/urovo/urovo_rfid
+repository: https://github.com/urovo/urovo_rfid
+issue_tracker: https://github.com/urovo/urovo_rfid/issues
+topics:
+  - rfid
+  - urovo
+  - android
+  - hardware
+  - plugin
 
 environment:
   sdk: ^3.8.1
@@ -35,7 +43,7 @@ flutter:
   plugin:
     platforms:
       android:
-        package: com.example.urovo_rfid
+        package: com.urovo.plugins.rfid
         pluginClass: UrovoRfidPlugin
 
   # To add assets to your plugin package, add an assets section, like this:


### PR DESCRIPTION
### Motivation
- Replace template placeholders and TODOs with production-ready metadata and documentation to make the package ready for publishing. 
- Normalize Android package/group/namespace identifiers to a stable production value for long-term maintenance.

### Description
- Replaced placeholder `description` and added `homepage`, `repository`, `issue_tracker`, and `topics` in `pubspec.yaml`, and set the plugin Android package to `com.urovo.plugins.rfid`.
- Rewrote `CHANGELOG.md` 0.0.1 entry with concrete release notes describing implemented APIs, Android-only scope, and known limitations.
- Expanded `README.md` with platform/device support, SDK prerequisites, installation steps, full API usage examples (init, inventory stream handling, read/write), error handling semantics, and Urovo hardware/permission guidance.
- Normalized Android production identifiers and moved source/test files to the new package: changed Gradle `group`/`namespace`, manifest `package`, Java/Kotlin `package` declarations and file paths to `com.urovo.plugins.rfid`, and updated the example app namespace/applicationId to `com.urovo.urovo_rfid_example`.

### Testing
- Ran a repository scan with `rg -n "com\.example" -S` to verify template `com.example...` identifiers were removed; check returned no remaining matches in the plugin sources.
- Attempted `flutter --version` and `flutter analyze` but both failed because Flutter is not installed in the execution environment (so static analysis could not be run here).
- Performed local workspace checks and committed the changes successfully (no functional API changes were introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbab3078a0832d86681db2cbce6fa1)