### PR TITLE
Align `setInventoryParameter` payload handling to use map arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,26 @@ Future<void> writeExample(UrovoRfid rfid, String epc) async {
 }
 ```
 
+### 5) Configure inventory parameters
+
+`setInventoryParameter` expects a Dart `Map<String, dynamic>` where keys map directly to Urovo `RfidParameter` fields.
+
+Currently supported keys:
+
+- `Session` (`int`)
+- `Interval` (`int`)
+- `QValue` (`int`)
+
+```dart
+Future<void> configureInventory(UrovoRfid rfid) async {
+  await rfid.setInventoryParameter({
+    'Session': 0,
+    'Interval': 0,
+    'QValue': 6,
+  });
+}
+```
+
 ## Error handling semantics
 
 This plugin exposes two error surfaces:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,6 @@ android {
         implementation files('libs/URFIDLibrary-v2.4.0125.aar')
 //        implementation(name: 'URFIDLibrary-v2.4.0125', ext: 'aar')
 
-        implementation 'com.google.code.gson:gson:2.10.1'
     }
 
     testOptions {

--- a/android/src/main/java/com/urovo/plugins/rfid/UrovoRfidPlugin.java
+++ b/android/src/main/java/com/urovo/plugins/rfid/UrovoRfidPlugin.java
@@ -7,7 +7,6 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import com.google.gson.Gson;
 import com.ubx.usdk.USDKManager;
 import com.ubx.usdk.bean.RfidParameter;
 import com.ubx.usdk.rfid.RfidManager;
@@ -16,6 +15,7 @@ import com.ubx.usdk.rfid.aidl.IRfidCallback;
 import org.json.JSONObject;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -289,15 +289,54 @@ public class UrovoRfidPlugin implements FlutterPlugin, ActivityAware, MethodCall
     }
 
     private void setInventoryParameter(MethodCall call) {
-        // Parameters are passed as a JSON string in the call argument "params".
-        String paramsJson = call.argument("params");
-        if (paramsJson == null) {
+        Object arguments = call.arguments;
+        if (!(arguments instanceof Map)) {
             return;
         }
-        RfidParameter rfidParameter = new Gson().fromJson(paramsJson, RfidParameter.class);
-        if (rfidParameter != null) {
-            rfidManager.setInventoryParameter(rfidParameter);
+
+        Map<?, ?> argumentMap = (Map<?, ?>) arguments;
+        Map<?, ?> params = argumentMap;
+
+        Object nestedParams = argumentMap.get("params");
+        if (nestedParams instanceof Map) {
+            params = (Map<?, ?>) nestedParams;
         }
+
+        RfidParameter rfidParameter = rfidManager.getInventoryParameter();
+        if (rfidParameter == null) {
+            rfidParameter = new RfidParameter();
+        }
+
+        Integer session = getInteger(params.get("Session"));
+        if (session != null) {
+            rfidParameter.Session = session;
+        }
+
+        Integer interval = getInteger(params.get("Interval"));
+        if (interval != null) {
+            rfidParameter.Interval = interval;
+        }
+
+        Integer qValue = getInteger(params.get("QValue"));
+        if (qValue != null) {
+            rfidParameter.QValue = qValue;
+        }
+
+        rfidManager.setInventoryParameter(rfidParameter);
+    }
+
+    private Integer getInteger(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Integer.parseInt((String) value);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 
     private void enableScanHead(MethodCall call, Result result) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -135,7 +135,11 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> _setInventoryParameter() async {
     try {
-      await _urovoRfidPlugin.setInventoryParameter({'dummy': true});
+      await _urovoRfidPlugin.setInventoryParameter({
+        'Session': 0,
+        'Interval': 0,
+        'QValue': 6,
+      });
       _log('setInventoryParameter');
     } catch (e) {
       _log('setInventoryParameter error: $e');


### PR DESCRIPTION
### Motivation
- Make Dart-to-Android payloads for `setInventoryParameter` consistent and avoid fragile JSON-string parsing. 
- Allow callers to pass a natural `Map<String, dynamic>` from Dart and map supported fields directly into the vendor `RfidParameter` object. 

### Description
- Replace JSON-string parsing in `setInventoryParameter` with map extraction from `call.arguments`, optionally unwrapping a nested `params` map, and map keys into an `RfidParameter` instance (`Session`, `Interval`, `QValue`) using a new `getInteger` helper in `android/src/main/java/com/urovo/plugins/rfid/UrovoRfidPlugin.java`.
- Preserve compatibility with the nested shape `{ 'params': { ... } }` if callers provide it.
- Update the example app (`example/lib/main.dart`) to send real supported keys (`'Session'`, `'Interval'`, `'QValue'`) instead of dummy data.
- Document the expected payload and supported keys in `README.md` with a usage snippet for `setInventoryParameter`.
- Remove the now-unused `Gson` dependency declaration from `android/build.gradle` since JSON deserialization is no longer used for this flow.

### Testing
- Attempted to run `dart format example/lib/main.dart`, but the command failed in this environment because the `dart` executable is not available (format step failed).
- Verified repository changes with `git diff` and `git status` as part of the change validation and committed the modifications successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4d964428832db90673edceb45485)