### PR TITLE
Normalize readTag contract across Android, method channel, and tests

### DIFF
--- a/android/src/main/java/com/urovo/plugins/rfid/UrovoRfidPlugin.java
+++ b/android/src/main/java/com/urovo/plugins/rfid/UrovoRfidPlugin.java
@@ -241,12 +241,16 @@ public class UrovoRfidPlugin implements FlutterPlugin, ActivityAware, MethodCall
         Integer wordCnt = call.argument("wordCnt");
         byte[] password = call.argument("password");
         if (memBank == null || wordAdd == null || wordCnt == null) {
-            result.success(ERR_CODE);
+            result.success(getReadTagResultMap(null, ERR_CODE));
             return;
         }
         String ret = rfidManager.readTag(epc, memBank.byteValue(),
                 wordAdd.byteValue(), wordCnt.byteValue(), password);
-        result.success(ret);
+        if (ret == null || ret.isEmpty()) {
+            result.success(getReadTagResultMap(null, ERR_CODE));
+            return;
+        }
+        result.success(getReadTagResultMap(ret, 0));
     }
 
     private void writeTag(MethodCall call, Result result) {
@@ -362,6 +366,18 @@ public class UrovoRfidPlugin implements FlutterPlugin, ActivityAware, MethodCall
                 eventSink.success(map);
             }
         });
+    }
+
+    /**
+     * Build a normalized readTag response consumed by Dart:
+     * {data: String?, status: "success"|"error", errorCode: int}
+     */
+    private Map<String, Object> getReadTagResultMap(String data, int errorCode) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("data", data);
+        response.put("status", errorCode == 0 ? "success" : "error");
+        response.put("errorCode", errorCode);
+        return response;
     }
 
     @Override

--- a/lib/urovo_rfid_method_channel.dart
+++ b/lib/urovo_rfid_method_channel.dart
@@ -51,7 +51,7 @@ class MethodChannelUrovoRfid extends UrovoRfidPlatform {
         'password': password,
       },
     );
-    return result;
+    return result == null ? null : Map<String, dynamic>.from(result);
   }
 
   @override

--- a/lib/urovo_rfid_platform_interface.dart
+++ b/lib/urovo_rfid_platform_interface.dart
@@ -39,8 +39,14 @@ abstract class UrovoRfidPlatform extends PlatformInterface {
   /// Stop any ongoing inventory scans.
   Future<void> stopInventory();
 
-  /// Read tag data from the specified memory [memBank].  The password is
-  /// supplied as a 4-byte array in [password].
+  /// Read tag data from the specified memory [memBank].
+  ///
+  /// Returns a structured map with these keys:
+  /// - `data`: tag payload when the read succeeds, otherwise `null`
+  /// - `status`: `"success"` or `"error"`
+  /// - `errorCode`: SDK/native error code where `0` represents success
+  ///
+  /// The password is supplied as a 4-byte array in [password].
   Future<Map<String, dynamic>?> readTag(
     String epc,
     int memBank,

--- a/test/urovo_rfid_method_channel_test.dart
+++ b/test/urovo_rfid_method_channel_test.dart
@@ -12,6 +12,13 @@ void main() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
       channel,
       (MethodCall methodCall) async {
+        if (methodCall.method == 'readTag') {
+          return <String, dynamic>{
+            'data': 'ABCD1234',
+            'status': 'success',
+            'errorCode': 0,
+          };
+        }
         return '42';
       },
     );
@@ -23,5 +30,16 @@ void main() {
 
   test('getPlatformVersion', () async {
     expect(await platform.getPlatformVersion(), '42');
+  });
+
+  test('readTag returns structured response map', () async {
+    expect(
+      await platform.readTag('300833B2DDD9014000000000', 1, 2, 6, <int>[0, 0, 0, 0]),
+      <String, dynamic>{
+        'data': 'ABCD1234',
+        'status': 'success',
+        'errorCode': 0,
+      },
+    );
   });
 }

--- a/test/urovo_rfid_test.dart
+++ b/test/urovo_rfid_test.dart
@@ -26,7 +26,11 @@ class MockUrovoRfidPlatform
   @override
   Future<Map<String, dynamic>?> readTag(
           String epc, int memBank, int wordAdd, int wordCnt, List<int> password) async =>
-      {};
+      <String, dynamic>{
+        'data': 'ABCD1234',
+        'status': 'success',
+        'errorCode': 0,
+      };
 
   @override
   Future<int?> writeTag(String epc, List<int> password, int memBank,
@@ -62,5 +66,26 @@ void main() {
     UrovoRfidPlatform.instance = fakePlatform;
 
     expect(await urovoRfidPlugin.getPlatformVersion(), '42');
+  });
+
+  test('readTag returns normalized map contract', () async {
+    UrovoRfid urovoRfidPlugin = UrovoRfid();
+    MockUrovoRfidPlatform fakePlatform = MockUrovoRfidPlatform();
+    UrovoRfidPlatform.instance = fakePlatform;
+
+    expect(
+      await urovoRfidPlugin.readTag(
+        '300833B2DDD9014000000000',
+        1,
+        2,
+        6,
+        <int>[0, 0, 0, 0],
+      ),
+      <String, dynamic>{
+        'data': 'ABCD1234',
+        'status': 'success',
+        'errorCode': 0,
+      },
+    );
   });
 }


### PR DESCRIPTION
### Motivation
- Ensure `readTag` returns a single, predictable shape across platform layers to simplify Dart-side handling and error cases.
- Convert SDK `readTag` responses into a structured map so callers can inspect `data`, `status`, and `errorCode` instead of dealing with raw strings or integers.
- Keep the method channel contract stable while updating the platform interface docs and tests to reflect the chosen shape.

### Description
- Android `readTag` now validates arguments and converts SDK output into a normalized map via `getReadTagResultMap(String data, int errorCode)` returning `{data, status, errorCode}`; error and empty-response paths return `status: "error"` and the native error code. (updated `android/src/main/java/com/urovo/plugins/rfid/UrovoRfidPlugin.java`)
- Method-channel implementation continues to use `invokeMapMethod` and now normalizes the returned dynamic map with `Map<String, dynamic>.from(...)` before returning. (updated `lib/urovo_rfid_method_channel.dart`)
- Platform interface documentation and the `readTag` signature comment were updated to document the response contract (`data`, `status`, `errorCode`). (updated `lib/urovo_rfid_platform_interface.dart`)
- Unit tests were extended to assert the new structured response in both the method-channel test and the public API test. (updated `test/urovo_rfid_method_channel_test.dart` and `test/urovo_rfid_test.dart`)

### Testing
- Added and updated automated tests: `test/urovo_rfid_method_channel_test.dart` and `test/urovo_rfid_test.dart` to validate the normalized `readTag` response map shape.
- Attempted to run `flutter test` but the `flutter` binary was not available in this environment, so tests were not executed here.
- Attempted to run `dart test` but the `dart` binary was not available in this environment, so tests were not executed here.
- The tests are expected to pass in CI or a local environment with Flutter/Dart installed; they assert the exact map `{ 'data': ..., 'status': 'success'|'error', 'errorCode': ... }` is returned.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51df8e33c832d99ffe58fc5019f60)